### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy-backend.yaml
+++ b/.github/workflows/deploy-backend.yaml
@@ -1,4 +1,6 @@
 name: deploy-backend
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/1ucycrabtree/budget-tracker-2025/security/code-scanning/1](https://github.com/1ucycrabtree/budget-tracker-2025/security/code-scanning/1)

To fix the problem, add a `permissions` key limiting the default permissions of the `GITHUB_TOKEN` for the workflow. Since neither the `deploy-staging` nor `deploy-prod` jobs nor their steps need to write to or modify GitHub repository contents, issues, or pull requests, set `permissions` at the workflow root. The minimum required permission is `contents: read`, which is typically enough for actions like checkout (reading repository files). Add the following block after the workflow name and before `on:`:

```yaml
permissions:
  contents: read
```

No additional imports or changes are required for this fix.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
